### PR TITLE
Set maximum number of substrings

### DIFF
--- a/Set-PsEnv.psm1
+++ b/Set-PsEnv.psm1
@@ -33,7 +33,7 @@ function Set-PsEnv {
 
     #load the content to environment
     foreach ($line in $content) {
-        $kvp = $line -split "="
+        $kvp = $line -split "=",2
         if ($PSCmdlet.ShouldProcess("$($kvp[0])", "set value $($kvp[1])")) {
             [Environment]::SetEnvironmentVariable($kvp[0], $kvp[1], "Process") | Out-Null
         }


### PR DESCRIPTION
For values that contain "=" symbols (like base 64 encoded strings), set the maximum number of sub-strings to 2

Example .env:
ARM_ACCESS_KEY=FakeStringb5rIsfBo0Yj8fINkhHRSXBM//n0TVNQRLnnQHFAWbecn1V/QGjFyiB4G+qJFt39+y7m4ys/a007ADzVD6A==
