### PR TITLE
Specify the path of .env file

### DIFF
--- a/Set-PsEnv.psm1
+++ b/Set-PsEnv.psm1
@@ -1,4 +1,6 @@
-$localEnvFile = ".\.env"
+param(
+    [string]$localEnvFile = ".\.env"
+)
 <#
 .Synopsis
 Exports environment variable from the .env file to the current process.


### PR DESCRIPTION
Fix #7 
Turn `localEnvFile` into a flag.
